### PR TITLE
Get mirror-core building with Coq 8.10

### DIFF
--- a/theories/Lambda/AutoSetoidRewriteRtac.v
+++ b/theories/Lambda/AutoSetoidRewriteRtac.v
@@ -232,9 +232,9 @@ Section setoid.
   Qed.
 
   Instance Injective_mrw_equiv_rw_ret {T} (rT : T -> T -> Prop) (a b : T)
-  : Injective (mrw_equiv rT (rw_ret a) (rw_ret b)) :=
-  { result := rT a b }.
+  : Injective (mrw_equiv rT (rw_ret a) (rw_ret b)).
   Proof using.
+    refine {| result := rT a b |}.
     unfold rw_ret. intros. red in H.
     specialize (H nil nil nil 0 0 _ (@TopSubst _ _ nil nil)).
     inv_all. assumption.

--- a/theories/Lambda/Expr.v
+++ b/theories/Lambda/Expr.v
@@ -244,9 +244,9 @@ Section expr.
   ; mentionsV := _mentionsV
   }.
 
-  Instance ExprOk_expr : ExprOk Expr_expr :=
-  { exprD_weaken := _
-  }.
+  Instance ExprOk_expr : ExprOk Expr_expr.
+  refine {| exprD_weaken := _
+  |}.
   { intros. eapply (@ExprFacts.lambda_exprD_weaken _ _ _ _ _ _ _ _ _ _ _).
     eapply H. }
   { eapply lambda_exprD_strengthenU_single. }

--- a/theories/Lambda/ExprTac.v
+++ b/theories/Lambda/ExprTac.v
@@ -53,16 +53,16 @@ Section some_lemmas.
 
   Global Instance Injective_typ2 {F : Type -> Type -> Type}
          {Typ2_F : Typ2 RType_typ F} {Typ2Ok_F : Typ2Ok Typ2_F} a b c d :
-    Injective (typ2 a b = typ2 c d) :=
-  { result := a = c /\ b = d }.
+    Injective (typ2 a b = typ2 c d).
+  refine {| result := a = c /\ b = d |}.
   abstract (
       eapply typ2_inj; eauto ).
   Defined.
 
   Global Instance Injective_typ1 {F : Type -> Type}
          {Typ1_F : Typ1 RType_typ F} {Typ2Ok_F : Typ1Ok Typ1_F} a b
-  : Injective (typ1 a = typ1 b) :=
-  { result := a = b }.
+  : Injective (typ1 a = typ1 b).
+  refine {| result := a = b |}.
   abstract (
       eapply typ1_inj; eauto ).
   Defined.
@@ -105,24 +105,26 @@ Section some_lemmas.
 
   Global Instance Injective_lambda_exprD_App tus tvs (e1 e2 : expr typ sym) (t : typ)
          (v : exprT tus tvs (typD t)):
-    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (App e1 e2) = Some v) := {
+    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (App e1 e2) = Some v).
+  Proof.
+    refine {|
       result := exists u v1 v2, ExprDsimul.ExprDenote.lambda_exprD tus tvs (typ2 u t) e1 = Some v1 /\
                                 ExprDsimul.ExprDenote.lambda_exprD tus tvs u e2 = Some v2 /\
                                 v = exprT_App v1 v2;
       injection := fun H => _
-    }.
-  Proof.
+    |}.
     autorewrite with exprD_rw in H.
     simpl in H. forward; inv_all; subst.
     do 3 eexists; repeat split; eassumption.
   Defined.
 
   Global Instance Injective_lambda_exprD_Inj tus tvs (f : sym) (t : typ) (v : exprT tus tvs (typD t)):
-    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (Inj f) = Some v) := {
+    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (Inj f) = Some v).
+  Proof.
+    refine {|
       result := exists v', symAs f t = Some v' /\ v = fun _ _ => v';
       injection := fun H => _
-    }.
-  Proof.
+    |}.
     autorewrite with exprD_rw in H.
     simpl in H. forward; inv_all; subst.
     eexists; repeat split.

--- a/theories/Lambda/RedAll.v
+++ b/theories/Lambda/RedAll.v
@@ -67,15 +67,15 @@ Section reducer.
   Instance Injective_var_termsP t var_terms tus tvs tus' tvs' P
   : Injective (@var_termsP tus (t :: tvs) tus' (t :: tvs')
                            (@None (expr typ sym) :: var_terms)
-                           P) :=
-    {| result := exists P',
+                           P).
+  Proof.
+    refine {| result := exists P',
                    @var_termsP tus tvs tus' tvs' var_terms P' /\
                    (forall us (vs : HList.hlist typD (t :: tvs))
                            us' (vs' : HList.hlist typD (t :: tvs')),
                       P us vs us' vs' ->
                       hlist_hd vs = hlist_hd vs' /\
                       P' us (hlist_tl vs) us' (hlist_tl vs')) |}.
-  Proof.
     refine (fun H =>
               match H in @var_termsP a b c d X P
                     return match b as b , d as d , X
@@ -91,7 +91,7 @@ Section reducer.
                                              hlist_hd vs = match eq_sym pf in _ = t return typD t with
                                                              | eq_refl => hlist_hd vs'
                                                            end /\
-                                             P' us (hlist_tl vs) us' (hlist_tl vs')) 
+                                             P' us (hlist_tl vs) us' (hlist_tl vs'))
                              | _ , _ , _ => fun _ => True
                            end P
               with

--- a/theories/Lambda/RewriteRelations.v
+++ b/theories/Lambda/RewriteRelations.v
@@ -192,9 +192,10 @@ Section setoid.
   Qed.
 
   Global Instance SucceedsE_ptrnRinj {T} p x res
-  : ptrn_ok p -> SucceedsE x (@ptrnRinj T p) res :=
-  { s_result := exists y, Succeeds y p res /\ x = Rinj y }.
-  intros.  eauto using Succeeds_ptrnRinj.
+  : ptrn_ok p -> SucceedsE x (@ptrnRinj T p) res.
+  intros.
+  refine {| s_result := exists y, Succeeds y p res /\ x = Rinj y |}.
+  eauto using Succeeds_ptrnRinj.
   Defined.
 
   Definition ptrnRflip {T : Type} (p : ptrn R T)
@@ -233,9 +234,10 @@ Section setoid.
   Qed.
 
   Global Instance SucceedsE_ptrnRflip {T} p x res
-  : ptrn_ok p -> SucceedsE x (@ptrnRflip T p) res :=
-  { s_result := exists y, Succeeds y p res /\ x = Rflip y }.
-  intros.  eauto using Succeeds_ptrnRflip.
+  : ptrn_ok p -> SucceedsE x (@ptrnRflip T p) res.
+  intros.
+  refine {| s_result := exists y, Succeeds y p res /\ x = Rflip y |}.
+  eauto using Succeeds_ptrnRflip.
   Defined.
 
   Definition ptrnRrespectsL {T U : Type}
@@ -292,10 +294,11 @@ Section setoid.
   Qed.
 
   Global Instance SucceedsE_ptrnRrespectsL {T U} pl pr x res
-  : ptrn_ok pl -> ptrn_ok pr -> SucceedsE x (@ptrnRrespectsL T U pl pr) res :=
-  { s_result := exists y z resL resR, Succeeds y pl resL /\ Succeeds z pr resR /\
-                          x = Rrespects y z /\ res = resL resR }.
-  intros.  eauto using Succeeds_ptrnRrespectsL.
+  : ptrn_ok pl -> ptrn_ok pr -> SucceedsE x (@ptrnRrespectsL T U pl pr) res.
+  intros.
+  refine {| s_result := exists y z resL resR, Succeeds y pl resL /\ Succeeds z pr resR /\
+                          x = Rrespects y z /\ res = resL resR |}.
+  eauto using Succeeds_ptrnRrespectsL.
   Defined.
 
   Definition ptrnRpointwiseL {T U : Type}
@@ -352,10 +355,11 @@ Section setoid.
   Qed.
 
   Global Instance SucceedsE_ptrnRpointwiseL {T U} pl pr x res
-  : ptrn_ok pl -> ptrn_ok pr -> SucceedsE x (@ptrnRpointwiseL T U pl pr) res :=
-  { s_result := exists y z resL resR, Succeeds y pl resL /\ Succeeds z pr resR /\
-                          x = Rpointwise y z /\ res = resL resR }.
-  intros.  eauto using Succeeds_ptrnRpointwiseL.
+  : ptrn_ok pl -> ptrn_ok pr -> SucceedsE x (@ptrnRpointwiseL T U pl pr) res.
+  intros.
+  refine {| s_result := exists y z resL resR, Succeeds y pl resL /\ Succeeds z pr resR /\
+                          x = Rpointwise y z /\ res = resL resR |}.
+  eauto using Succeeds_ptrnRpointwiseL.
   Defined.
 
   Section refl_trans_types.

--- a/theories/MTypes/BaseType.v
+++ b/theories/MTypes/BaseType.v
@@ -67,28 +67,28 @@ Section FuncView_base_type.
 
   Definition ptrn_tyNat : ptrn (base_typ 0) (base_typ 0) :=
     fun f U good bad =>
-      match f with
+      match f return _ with
       | tNat => good f
       | _ => bad f
       end.
 
   Definition ptrn_tyBool : ptrn (base_typ 0) (base_typ 0) :=
     fun f U good bad =>
-      match f with
+      match f return _ with
       | tBool => good f
       | _ => bad f
       end.
 
   Definition ptrn_tyString : ptrn (base_typ 0) (base_typ 0) :=
     fun f U good bad =>
-      match f with
+      match f return _ with
       | tString => good f
       | _ => bad f
       end.
 
   Definition ptrn_tyProp : ptrn (base_typ 0) (base_typ 0) :=
     fun f U good bad =>
-      match f with
+      match f return _ with
       | tProp => good f
       | _ => bad f
       end.
@@ -156,5 +156,5 @@ Section RelDec_base_type.
     remember (base_typ_dec x0 y).
     destruct s; subst; intuition.
   Qed.
-  
+
 End RelDec_base_type.

--- a/theories/MTypes/ModularTypes.v
+++ b/theories/MTypes/ModularTypes.v
@@ -71,11 +71,11 @@ Section parametric.
 
   Section mtyp_ind.
     Variable P : mtyp -> Prop.
-    Hypotheses  (Harr : forall {a b}, P a -> P b -> P (tyArr a b))
+    Hypotheses  (Harr : forall a b, P a -> P b -> P (tyArr a b))
                 (Hbase0 : forall s, P (tyBase0 s))
-                (Hbase1 : forall s {a}, P a -> P (tyBase1 s a))
-                (Hbase2 : forall s {a b}, P a -> P b -> P (tyBase2 s a b))
-                (Happ : forall {n} s ms, ForallV P ms -> P (@tyApp n s ms)).
+                (Hbase1 : forall s a, P a -> P (tyBase1 s a))
+                (Hbase2 : forall s a b, P a -> P b -> P (tyBase2 s a b))
+                (Happ : forall n s ms, ForallV P ms -> P (@tyApp n s ms)).
     Fixpoint mtyp_ind (x : mtyp) : P x :=
       match x as x return P x with
       | tyArr a b => Harr _ _ (mtyp_ind a) (mtyp_ind b)
@@ -122,11 +122,11 @@ Section parametric.
   Defined.
 
   Instance Injective_tyApp {n n'} {s : symbol (3+n)} {s' : symbol (3+n')}
-           ms ms' : Injective (tyApp s ms = tyApp s' ms') :=
-  { result := forall pf : n' = n,
-      s = match pf with eq_refl => s' end /\
-      ms = match pf with eq_refl => ms' end }.
+           ms ms' : Injective (tyApp s ms = tyApp s' ms').
   Proof.
+    refine {| result := forall pf : n' = n,
+      s = match pf with eq_refl => s' end /\
+      ms = match pf with eq_refl => ms' end |}.
     intros.
     refine (match H in _ = (@tyApp n' l r)
                   return forall pf : n' = n,

--- a/theories/MTypes/TSyms.v
+++ b/theories/MTypes/TSyms.v
@@ -8,9 +8,9 @@ Section sum.
 
   Variable TSym_T : TSym T.
   Variable TSym_U : TSym U.
- 
-  Instance TSym_sum : TSym tsym_sum :=
-  { symbolD := fun n x =>
+
+  Instance TSym_sum : TSym tsym_sum.
+  refine {| symbolD := fun n x =>
                  match x in tsym_sum _ return type_for_arity n with
                  | TSym_left _ x => symbolD _ x
                  | TSym_right _ x => symbolD _ x
@@ -34,7 +34,7 @@ Section sum.
                     | TSym_left _ x , TSym_right _ y =>
                       right (fun _ => _)
                     end
-  }.
+  |}.
   all: congruence.
   Defined.
 End sum.

--- a/theories/RTac/Core.v
+++ b/theories/RTac/Core.v
@@ -90,18 +90,22 @@ Section parameterized.
 
 
   Global Instance Injective_WellFormed_Goal_GAll tus tvs t g
-  : Injective (WellFormed_Goal tus tvs (GAll t g)) :=
-    { result := WellFormed_Goal tus (tvs ++ t :: nil) g }.
-  Proof. inversion 1; auto. Defined.
-  Global Instance Injective_WellFormed_Goal_GHyp tus tvs t g
-  : Injective (WellFormed_Goal tus tvs (GHyp t g)) :=
-    { result := WellFormed_Goal tus tvs g }.
-  Proof. inversion 1; auto. Defined.
-  Global Instance Injective_WellFormed_Goal_GExs tus tvs l a g
-  : Injective (WellFormed_Goal tus tvs (GExs l a g)) :=
-    { result := WellFormed_Goal (tus ++ l) tvs g /\
-                WellFormed_bimap (length tus) (length l) (length tvs) a }.
+  : Injective (WellFormed_Goal tus tvs (GAll t g)).
   Proof.
+    refine {| result := WellFormed_Goal tus (tvs ++ t :: nil) g |}.
+    inversion 1; auto.
+  Defined.
+  Global Instance Injective_WellFormed_Goal_GHyp tus tvs t g
+  : Injective (WellFormed_Goal tus tvs (GHyp t g)).
+  Proof.
+    refine {| result := WellFormed_Goal tus tvs g |}.
+    inversion 1; auto.
+  Defined.
+  Global Instance Injective_WellFormed_Goal_GExs tus tvs l a g
+  : Injective (WellFormed_Goal tus tvs (GExs l a g)).
+  Proof.
+    refine {| result := WellFormed_Goal (tus ++ l) tvs g /\
+                WellFormed_bimap (length tus) (length l) (length tvs) a |}.
     refine (fun pf =>
               match pf in WellFormed_Goal _ _ G
                     return match G return Prop with
@@ -116,9 +120,11 @@ Section parameterized.
               end).
   Defined.
   Global Instance Injective_WellFormed_Goal_GConj tus tvs a b
-  : Injective (WellFormed_Goal tus tvs (GConj_ a b)) :=
-  { result := WellFormed_Goal tus tvs a /\ WellFormed_Goal tus tvs b }.
-  Proof. inversion 1. auto. Defined.
+  : Injective (WellFormed_Goal tus tvs (GConj_ a b)).
+  Proof.
+    refine {| result := WellFormed_Goal tus tvs a /\ WellFormed_Goal tus tvs b |}.
+    inversion 1. auto.
+  Defined.
 
 
   Definition GAlls (ts : list typ) (g : Goal) : Goal :=

--- a/theories/RTac/Ctx.v
+++ b/theories/RTac/Ctx.v
@@ -286,9 +286,10 @@ Section parameterized.
     end.
 
   Global Instance Injective_HypSubst h c s s'
-  : Injective (@HypSubst h c s = @HypSubst h c s') :=
-    { result := s = s' }.
-  Proof. clear.
+  : Injective (@HypSubst h c s = @HypSubst h c s').
+  Proof.
+   refine {| result := s = s' |}.
+   clear.
    refine (fun pf =>
              match pf in _ = Z
                    return match Z in ctx_subst c return ctx_subst c -> Prop with
@@ -301,9 +302,9 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_AllSubst h c s s'
-  : Injective (@AllSubst h c s = @AllSubst h c s') :=
-    { result := s = s' }.
+  : Injective (@AllSubst h c s = @AllSubst h c s').
   Proof using.
+   refine {| result := s = s' |}.
    refine (fun pf =>
              match pf in _ = Z
                    return match Z in ctx_subst c return ctx_subst c -> Prop with
@@ -678,9 +679,9 @@ Section parameterized.
   }.
 
   Global Instance Injective_ExsSubst ts ctx a b c d
-  : Injective (ExsSubst (ts:=ts)(c:=ctx) a b = ExsSubst c d) :=
-    { result := a = c /\ b = d }.
+  : Injective (ExsSubst (ts:=ts)(c:=ctx) a b = ExsSubst c d).
   Proof using.
+  refine {| result := a = c /\ b = d |}.
   intro pf.
   refine (match pf in _ = X return
                 match X with
@@ -694,9 +695,9 @@ Section parameterized.
 
 
   Global Instance Injective_WellFormed_ctx_subst_All c t s
-  : Injective (WellFormed_ctx_subst (AllSubst (c:=c) (t:=t) s)) :=
-  { result := WellFormed_ctx_subst s }.
+  : Injective (WellFormed_ctx_subst (AllSubst (c:=c) (t:=t) s)).
   Proof using.
+    refine {| result := WellFormed_ctx_subst s |}.
     refine (fun x =>
               match x in WellFormed_ctx_subst z
                     return match z return Prop with
@@ -710,9 +711,9 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_WellFormed_ctx_subst_Hyp c t s
-  : Injective (WellFormed_ctx_subst (HypSubst (c:=c) (t:=t) s)) :=
-  { result := WellFormed_ctx_subst s }.
+  : Injective (WellFormed_ctx_subst (HypSubst (c:=c) (t:=t) s)).
   Proof using.
+    refine {| result := WellFormed_ctx_subst s |}.
     refine (fun x =>
               match x in WellFormed_ctx_subst z
                     return match z return Prop with
@@ -726,15 +727,14 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_WellFormed_ctx_subst_Top tus tvs
-  : Injective (WellFormed_ctx_subst (TopSubst tus tvs)) :=
-  { result := True }.
-  Proof using. trivial. Defined.
+  : Injective (WellFormed_ctx_subst (TopSubst tus tvs)).
+  Proof using. refine {| result := True |}. trivial. Defined.
 
   Global Instance Injective_WellFormed_ctx_subst_ExsSubst ctx ts c s
-  : Injective (WellFormed_ctx_subst (c:=CExs ctx ts) (ExsSubst c s)) :=
-  { result := WellFormed_ctx_subst c /\
-              WellFormed_entry c (length ts) s }.
+  : Injective (WellFormed_ctx_subst (c:=CExs ctx ts) (ExsSubst c s)).
   Proof using.
+  refine {| result := WellFormed_ctx_subst c /\
+              WellFormed_entry c (length ts) s |}.
   intro.
   refine match H in @WellFormed_ctx_subst C s
                return match C as C return ctx_subst C -> Prop with
@@ -960,10 +960,10 @@ Section parameterized.
   Qed.
 
   Global Instance SubstOk_ctx_subst ctx
-  : @SubstOk (ctx_subst ctx) typ expr _ _ _ :=
-  { WellFormed_subst := @WellFormed_ctx_subst ctx
+  : @SubstOk (ctx_subst ctx) typ expr _ _ _.
+  refine {| WellFormed_subst := @WellFormed_ctx_subst ctx
   ; substD := @ctx_substD ctx
-  }.
+  |}.
   { intros; eapply ctx_substD_lookup; eassumption. }
   { intros; eapply ctx_subst_domain; eassumption. }
   { intros; eapply ctx_lookup_normalized; eassumption. }
@@ -1307,9 +1307,9 @@ Section parameterized.
   Qed.
 
   Global Instance Injective_SubstMorphism_AllSubst t ctx s s'
-  : Injective (@SubstMorphism (CAll ctx t) (AllSubst s) s') :=
-  { result := exists s'', s' = AllSubst s'' /\ @SubstMorphism ctx s s'' }.
+  : Injective (@SubstMorphism (CAll ctx t) (AllSubst s) s').
   Proof using.
+  refine {| result := exists s'', s' = AllSubst s'' /\ @SubstMorphism ctx s s'' |}.
   intros.
   exists (fromAll s').
   refine
@@ -1328,8 +1328,8 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_SubstMorphism_HypSubst t ctx s s'
-  : Injective (@SubstMorphism (CHyp ctx t) (HypSubst s) s') :=
-  { result := exists s'', s' = HypSubst s'' /\ @SubstMorphism ctx s s'' }.
+  : Injective (@SubstMorphism (CHyp ctx t) (HypSubst s) s').
+  refine {| result := exists s'', s' = HypSubst s'' /\ @SubstMorphism ctx s s'' |}.
   clear. intros.
   exists (fromHyp s').
   refine
@@ -1348,9 +1348,9 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_SubstMorphism_TopSubst tus tvs s'
-  : Injective (@SubstMorphism (CTop tus tvs) (TopSubst _ _) s') :=
-  { result := s' = TopSubst tus tvs }.
+  : Injective (@SubstMorphism (CTop tus tvs) (TopSubst _ _) s').
   Proof using.
+  refine {| result := s' = TopSubst tus tvs |}.
     intros.
     refine
       (match H in @SubstMorphism C X Y
@@ -1365,8 +1365,9 @@ Section parameterized.
   Defined.
 
   Global Instance Injective_SubstMorphism_ExsSubst ctx tes s s' sub
-  : Injective (@SubstMorphism (CExs ctx tes) (ExsSubst sub s) s') :=
-  { result := exists s'' sub',
+  : Injective (@SubstMorphism (CExs ctx tes) (ExsSubst sub s) s').
+  Proof using.
+  refine {| result := exists s'' sub',
                 s' = ExsSubst sub' s''
                 /\ (match @pctxD ctx sub
                         , amap_substD ((getUVars ctx) ++ tes) (getVars ctx) s
@@ -1383,8 +1384,7 @@ Section parameterized.
                                                s2D (hlist_app us us') vs ->
                                                s1D (hlist_app us us') vs) us vs
                     end)
-                /\ SubstMorphism sub sub'}.
-  Proof using.
+                /\ SubstMorphism sub sub'|}.
   intros. exists (fst (fromExs s')). exists (snd (fromExs s')).
   refine
     (match H in @SubstMorphism C X Y
@@ -2109,7 +2109,7 @@ Section parameterized.
         split.
         { generalize H. intro SAVE_WF.
           eapply WellFormed_entry_check_set in H; eauto.
-          { 
+          {
             apply and_comm.
             eapply mentionsAny_conj_false. simpl.
             eapply mentionsAny_complete_false; eauto.
@@ -2255,7 +2255,7 @@ Section parameterized.
             eapply Pure_pctxD; eauto.
             intros. eapply H21 in H22. tauto. }
           { clear - H15 H17 H19 H7 H13.
-            split; intros. 
+            split; intros.
             { intuition. rewrite <- H19; auto.
               eapply H17 in H0.
               destruct H0. rewrite H0; clear H0.
@@ -2491,10 +2491,10 @@ Section parameterized.
   Qed.
 
   Global Instance SubstUpdateOk_ctx_subst ctx
-  : SubstUpdateOk (ctx_subst ctx) typ expr :=
-  { substR := fun _ _ a b => SubstMorphism a b
-  ; set_sound := _ }.
+  : SubstUpdateOk (ctx_subst ctx) typ expr.
   Proof.
+  refine {| substR := fun _ _ a b => SubstMorphism a b
+  ; set_sound := _ |}.
     intros. eapply ctx_substD_set; eauto.
   Defined.
 

--- a/theories/Subst/FMapSubst.v
+++ b/theories/Subst/FMapSubst.v
@@ -1158,9 +1158,9 @@ Module Make (FM : WS with Definition E.t := uvar
     }.
 
     Instance SubstOpenOk_subst
-    : @SubstOpenOk raw typ expr _ _ _ _ SubstOpen_subst :=
-    { drop_sound := substD_drop' }.
+    : @SubstOpenOk raw typ expr _ _ _ _ SubstOpen_subst.
     Proof.
+      refine {| drop_sound := substD_drop' |}.
       unfold subst_weakenU; simpl.
       intros; subst.
       eapply substD_weaken with (tus' := tus') (tvs' := nil) in H1.

--- a/theories/Views/FuncView.v
+++ b/theories/Views/FuncView.v
@@ -120,11 +120,11 @@ Section FuncView.
   Defined.
 
   Global Instance Injective_exprD'_f_insert (a : A) (t : typ) (v : typD t)
-  : Injective (symAs (f_insert a) t = Some v) :=
-  { result := symAs a t = Some v
-  ; injection := fun H => _
-  }.
+  : Injective (symAs (f_insert a) t = Some v).
   Proof.
+    refine {| result := symAs a t = Some v
+  ; injection := fun H => _
+  |}.
     rewrite fv_compat; assumption.
   Defined.
 

--- a/theories/Views/ProdView.v
+++ b/theories/Views/ProdView.v
@@ -32,24 +32,26 @@ Section ExprDInject.
 
   Global Instance Injective_lambda_exprD_App tus tvs (e1 e2 : expr typ func) (t : typ)
          (v : exprT tus tvs (typD t)):
-    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (App e1 e2) = Some v) := {
+    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (App e1 e2) = Some v).
+  Proof.
+    refine {|
       result := exists u v1 v2, ExprDsimul.ExprDenote.lambda_exprD tus tvs (tyArr u t) e1 = Some v1 /\
                                 ExprDsimul.ExprDenote.lambda_exprD tus tvs u e2 = Some v2 /\
                                 v = AbsAppI.exprT_App v1 v2;
       injection := fun H => _
-    }.
-  Proof.
+    |}.
     autorewrite with exprD_rw in H.
     simpl in H. forward; inv_all; subst.
     do 3 eexists; repeat split; eassumption.
   Defined.
 
   Global Instance Injective_lambda_exprD_Inj tus tvs (f : func) (t : typ) (v : exprT tus tvs (typD t)):
-    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (Inj f) = Some v) := {
+    Injective (ExprDsimul.ExprDenote.lambda_exprD tus tvs t (Inj f) = Some v).
+  Proof.
+    refine {|
       result := exists v', symAs f t = Some v' /\ v = fun _ _ => v';
       injection := fun H => _
-    }.
-  Proof.
+    |}.
     autorewrite with exprD_rw in H.
     simpl in H. forward; inv_all; subst.
     eexists; repeat split.

--- a/theories/Views/Ptrns.v
+++ b/theories/Views/Ptrns.v
@@ -283,7 +283,7 @@ Section setoid.
   ; injection := @Succeeds_get _ _ }.
 *)
 
-  Global Polymorphic Class SucceedsE {T : Type} (f : X) (p : ptrn T) (v : T) :=
+  Polymorphic Class SucceedsE {T : Type} (f : X) (p : ptrn T) (v : T) :=
   { s_result : Prop
   ; s_elim : Succeeds f p v -> s_result
   }.

--- a/theories/syms/SymOneOf.v
+++ b/theories/syms/SymOneOf.v
@@ -217,7 +217,7 @@ Module OneOfType.
     unfold asNth.
     destruct oe; simpl.
     revert value0. revert index0. revert ts.
-    induction p; destruct index0; simpl; intros; 
+    induction p; destruct index0; simpl; intros;
     try congruence; eapply IHp in H; inv_all; subst; reflexivity.
   Defined.
 
@@ -434,8 +434,8 @@ Section RSym_OneOf.
                                 | _None => Empty_set
                                 end)
            (H2 : forall p, RSymOk (H1 p))
-  : RSymOk (RSymOneOf m H1) :=
-  { sym_eqbOk f1 f2 :=
+  : RSymOk (RSymOneOf m H1).
+  refine {| sym_eqbOk f1 f2 :=
       match f1 as f1'
             return match sym_eqb f1' f2 return Prop with
                    | Some true => f1' = f2
@@ -455,7 +455,7 @@ Section RSym_OneOf.
           | mkOneOf _ x2 v2 => _
           end
       end
-  }.
+  |}.
   simpl. unfold sym_eqb_OneOf. simpl.
   destruct (Pos.eq_dec x1 x2).
   { destruct e.


### PR DESCRIPTION
Tested `make` with Coq 8.10.0 and 8.9.1.  This builds with both of them assuming the version of coq-ext-lib you have is https://github.com/coq-community/coq-ext-lib/pull/76.

There were three errors that needed fixing:
1. The universe inconsistency fixed by https://github.com/coq-community/coq-ext-lib/pull/76
2. Unless `Refine Instance Mode` is set (I think it's deprecated and going away), `Instance foo := <partial term>. Proof. <more stuff>. Defined.` is no longer valid, and instead you need to `refine` with the partial term.  Rather than just setting `Refine Instance Mode`, I've changed the instance declarations over for more forward-compatibility.
3. Apparently the order in which return match inference is done changed and `match` got more eager about eliminating impossible branches.  This was causing a later `destruct` to fail.  Adding `return _` forced a non-dependent return clause, allowing the later `destruct` to succeed.